### PR TITLE
Add missing link to repository on endpoint-sec(-sys)

### DIFF
--- a/endpoint-sec-sys/Cargo.toml
+++ b/endpoint-sec-sys/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 authors.workspace = true
 license.workspace = true
 edition.workspace = true
+repository.workspace = true
 rust-version.workspace = true
 
 description = "Raw Rust wrappers around the Endpoint Security Framework"

--- a/endpoint-sec/Cargo.toml
+++ b/endpoint-sec/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 authors.workspace = true
 license.workspace = true
 edition.workspace = true
+repository.workspace = true
 rust-version.workspace = true
 
 description = "High-level Rust wrappers around the Endpoint Security Framework"


### PR DESCRIPTION
Was missing for initial release.