### PR TITLE
Fix warnings on doc with default features

### DIFF
--- a/endpoint-sec-sys/src/client.rs
+++ b/endpoint-sec-sys/src/client.rs
@@ -132,7 +132,8 @@ extern "C" {
     /// - `client`: The client for which events will be suppressed
     /// - `audit_token`: The audit token of the process for which events will be suppressed
     ///
-    /// See [`es_mute_process_events()`]
+    #[cfg_attr(feature = "macos_12_0_0", doc = "See [`es_mute_process_events()`]")]
+    #[cfg_attr(not(feature = "macos_12_0_0"), doc = "See `es_mute_process_events()`")]
     pub fn es_mute_process(client: *mut es_client_t, audit_token: *const audit_token_t) -> es_return_t;
 
     /// Suppress a subset of events from the process described by the given `audit_token`
@@ -156,7 +157,8 @@ extern "C" {
     /// - `client`: The client for which the process will be unmuted
     /// - `audit_token`: The audit token of the process to be unmuted
     ///
-    /// See [`es_unmute_process_events()`]
+    #[cfg_attr(feature = "macos_12_0_0", doc = "See [`es_unmute_process_events()`]")]
+    #[cfg_attr(not(feature = "macos_12_0_0"), doc = "See `es_unmute_process_events()`")]
     pub fn es_unmute_process(client: *mut es_client_t, audit_token: *const audit_token_t) -> es_return_t;
 
     /// Unmute a process for a subset of event types.
@@ -363,7 +365,14 @@ extern "C" {
 
     /// Suppress events matching a path prefix
     ///
-    /// **Deprecated in macOS 11**: Please use [`es_mute_path()`] or [`es_mute_path_events()`]
+    #[cfg_attr(
+        feature = "macos_12_0_0",
+        doc = "**Deprecated in macOS 12**: Please use [`es_mute_path()`] or [`es_mute_path_events()`]"
+    )]
+    #[cfg_attr(
+        not(feature = "macos_12_0_0"),
+        doc = "**Deprecated in macOS 12**: Please use `es_mute_path()` or `es_mute_path_events()`"
+    )]
     ///
     /// - `client`: The client for which events will be suppressed
     /// - `path_prefix`: The path against which supressed executables must prefix match
@@ -371,20 +380,40 @@ extern "C" {
 
     /// Suppress events matching a path literal
     ///
-    /// **Deprecated in macOS 11**: Please use [`es_mute_path()`] or [`es_mute_path_events()`]
+    #[cfg_attr(
+        feature = "macos_12_0_0",
+        doc = "**Deprecated in macOS 12**: Please use [`es_mute_path()`] or [`es_mute_path_events()`]"
+    )]
+    #[cfg_attr(
+        not(feature = "macos_12_0_0"),
+        doc = "**Deprecated in macOS 12**: Please use `es_mute_path()` or `es_mute_path_events()`"
+    )]
     ///
     /// - `client`: The client for which events will be suppressed
     /// - `path_literal`: The path against which supressed executables must match exactly
     ///
-    /// See [`es_mute_path()`]
-    /// See [`es_mute_path_events()`]
+    #[cfg_attr(
+        feature = "macos_12_0_0",
+        doc = "See [`es_mute_path()`] and [`es_mute_path_events()`]"
+    )]
+    #[cfg_attr(
+        not(feature = "macos_12_0_0"),
+        doc = "See `es_mute_path()` and `es_mute_path_events()`"
+    )]
     pub fn es_mute_path_literal(client: *mut es_client_t, path_literal: *const c_char) -> es_return_t;
 
     /// Unmute all paths
     ///
     /// - `client`: The client for which all currently muted paths will be unmuted
     ///
-    /// Only unmutes **executable** paths. To unmute target paths see [`es_unmute_all_target_paths()`].
+    #[cfg_attr(
+        feature = "macos_13_0_0",
+        doc = "Only unmutes **executable** paths. To unmute target paths see [`es_unmute_all_target_paths()`]."
+    )]
+    #[cfg_attr(
+        not(feature = "macos_13_0_0"),
+        doc = "Only unmutes **executable** paths. To unmute target paths see `es_unmute_all_target_paths()`."
+    )]
     pub fn es_unmute_all_paths(client: *mut es_client_t) -> es_return_t;
 
     /// Unmute all target paths
@@ -624,12 +653,19 @@ extern "C" {
     /// See also:
     ///
     /// - [`es_retain_message()`][erm]
-    /// - [`es_release_message()`][super::es_release_message]
+    #[cfg_attr(feature = "macos_11_0_0", doc = "- [`es_release_message()`]")]
+    #[cfg_attr(not(feature = "macos_11_0_0"), doc = "- `es_release_message()`")]
     /// - [`es_new_client_result_t`]
-    /// - [`es_muted_paths_events()`]
-    /// - [`es_unmute_path_events()`]
+    #[cfg_attr(
+        feature = "macos_12_0_0",
+        doc = "- [`es_muted_paths_events()`]\n- [`es_unmute_path_events()`]"
+    )]
+    #[cfg_attr(
+        not(feature = "macos_12_0_0"),
+        doc = "- `es_muted_paths_events()`\n- `es_unmute_path_events()`"
+    )]
     ///
-    /// [erm]: super::es_retain_message
+    /// [erm]: [es_retain_message]
     /// [not-perm]: crate::es_new_client_result_t::ES_NEW_CLIENT_RESULT_ERR_NOT_PERMITTED
     #[allow(improper_ctypes)]
     // In this specific case, it is okay because the block is called as

--- a/endpoint-sec-sys/src/message.rs
+++ b/endpoint-sec-sys/src/message.rs
@@ -259,7 +259,9 @@ pub struct es_btm_launch_item_t {
 ///
 /// Process arguments, environment variables and file descriptors are packed, use API functions
 /// to access them: [`es_exec_arg()`], [`es_exec_arg_count()`], [`es_exec_env()`],
-/// [`es_exec_env_count()`], [`es_exec_fd()`] and [`es_exec_fd_count()`].
+/// [`es_exec_env_count()`],
+#[cfg_attr(feature = "macos_11_0_0", doc = "[`es_exec_fd()`] and [`es_exec_fd_count()`].")]
+#[cfg_attr(not(feature = "macos_11_0_0"), doc = "`es_exec_fd()` and `es_exec_fd_count()`.")]
 ///
 /// The API may only return descriptions for a subset of open file descriptors; how many and
 /// which file descriptors are available as part of exec events is not considered API and can change
@@ -2362,7 +2364,15 @@ extern "C" {
     /// (e.g. by using the reported size in order to `malloc(3)` a buffer, and `memcpy(3)` an
     /// existing `es_message_t` into that buffer). Doing so will result in use-after-free bugs.
     ///
-    /// **Deprecated in macOS 11+*: Please use [`es_retain_message()`] to retain an `es_message_t`.
+    ///
+    #[cfg_attr(
+        feature = "macos_11_0_0",
+        doc = "**Deprecated in macOS 11+**: Please use [`es_retain_message()`] to retain an `es_message_t`."
+    )]
+    #[cfg_attr(
+        not(feature = "macos_11_0_0"),
+        doc = "**Deprecated in macOS 11+**: Please use `es_retain_message()` to retain an `es_message_t`."
+    )]
     ///
     /// - `msg`: The message for which the size will be calculated
     /// - Returns the size of the message
@@ -2374,7 +2384,14 @@ extern "C" {
     /// It is invalid to attempt to write to the returned `es_message_t`, despite being non-`const`,
     /// and doing so will result in a crash.
     ///
-    /// **Deprecated in macOS 11+*: Please use [`es_retain_message()`] to retain an `es_message_t`.
+    #[cfg_attr(
+        feature = "macos_11_0_0",
+        doc = "**Deprecated in macOS 11+**: Please use [`es_retain_message()`] to retain an `es_message_t`."
+    )]
+    #[cfg_attr(
+        not(feature = "macos_11_0_0"),
+        doc = "**Deprecated in macOS 11+**: Please use `es_retain_message()` to retain an `es_message_t`."
+    )]
     ///
     /// - `msg`: The message to be retained
     /// - Returns a non-const pointer to the retained `es_message_t`
@@ -2385,8 +2402,14 @@ extern "C" {
     /// Releases the memory associated with the given [`es_message_t`] that was retained via
     /// [`es_copy_message()`]
     ///
-    /// **Deprecated in macOS 11+*: Please use [`es_release_message()`] to release an
-    /// `es_message_t`.
+    #[cfg_attr(
+        feature = "macos_11_0_0",
+        doc = "**Deprecated in macOS 11+**: Please use [`es_retain_message()`] to retain an `es_message_t`."
+    )]
+    #[cfg_attr(
+        not(feature = "macos_11_0_0"),
+        doc = "**Deprecated in macOS 11+**: Please use `es_retain_message()` to retain an `es_message_t`."
+    )]
     ///
     /// - `msg`: The message to be released
     pub fn es_free_message(msg: &es_message_t);

--- a/endpoint-sec/src/client.rs
+++ b/endpoint-sec/src/client.rs
@@ -366,16 +366,31 @@ impl Client {
 
     /// Mute a path for all event types.
     ///
-    /// See [`es_mute_path`].
+    #[cfg_attr(feature = "macos_12_0_0", doc = "See [`es_mute_path`].")]
+    #[cfg_attr(not(feature = "macos_12_0_0"), doc = "See `es_mute_path`.")]
     ///
     /// # Note
     ///
     /// The C function takes a `const char * _Nonnull path`, which means it expects a nul-
     /// terminated string. Since the functions to gather such paths give [`OsString`]s (ex:
-    /// [`Self::muted_paths_events`]), this method will truncate the given `path` to the first `\0`
+    #[cfg_attr(
+        feature = "macos_12_0_0",
+        doc = "[`Self::muted_paths_events`]), this method will truncate the given `path` to the first `\0`"
+    )]
+    #[cfg_attr(
+        not(feature = "macos_12_0_0"),
+        doc = "`Self::muted_paths_events`), this method will truncate the given `path` to the first `\0`"
+    )]
     /// if it has one or add it itself if it does not (in which case there will be an allocation).
     ///
-    /// - If called on macOS 12.0+: uses [`es_mute_path()`].
+    #[cfg_attr(
+        feature = "macos_12_0_0",
+        doc = "- If called on macOS 12.0+: uses [`es_mute_path()`]."
+    )]
+    #[cfg_attr(
+        not(feature = "macos_12_0_0"),
+        doc = "- If called on macOS 12.0+: uses `es_mute_path()`."
+    )]
     /// - If called on macOS 10.15 or 11: uses [`es_mute_path_prefix()`] and [`es_mute_path_literal()`] accordingly.
     #[doc(alias = "es_mute_path")]
     #[doc(alias = "es_mute_path_prefix")]

--- a/endpoint-sec/src/message.rs
+++ b/endpoint-sec/src/message.rs
@@ -40,7 +40,14 @@ impl Message {
     /// # Details
     ///
     /// On macOS 11.0+, with the feature `"macos_11_0_0"` (or more) active, this uses
-    /// [`es_retain_message()`], which is basically an `Arc::clone()`.
+    #[cfg_attr(
+        feature = "macos_11_0_0",
+        doc = "[`es_retain_message()`], which is basically an `Arc::clone()`."
+    )]
+    #[cfg_attr(
+        not(feature = "macos_11_0_0"),
+        doc = "`es_retain_message()`, which is basically an `Arc::clone()`."
+    )]
     ///
     /// On macOS 10.15.x, this calls [`es_copy_message()`].
     #[inline(always)]
@@ -368,7 +375,14 @@ impl<'a> Process<'a> {
 
     /// Parent pid of the process.
     ///
-    /// **Warning**: It is recommended to instead use [`Self::parent_audit_token()`] when available.
+    #[cfg_attr(
+        feature = "macos_11_0_0",
+        doc = "**Warning**: It is recommended to instead use [`Self::parent_audit_token()`] when available."
+    )]
+    #[cfg_attr(
+        not(feature = "macos_11_0_0"),
+        doc = "**Warning**: It is recommended to instead use `Self::parent_audit_token()` when available."
+    )]
     #[inline(always)]
     pub fn ppid(&self) -> pid_t {
         self.raw.ppid


### PR DESCRIPTION
Fix almost all warnings (except macro based ones) because of link to feature gated functions.