### PR TITLE
deps: less precise versions to avoid dep bots updating patch versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ endpoint-sec = { version = "0.2.0", path = "./endpoint-sec" }
 endpoint-sec-sys = { version = "0.2.0", path = "./endpoint-sec-sys" }
 
 # External - Required
-block2 = "0.2.0"
+block2 = "0.2"
 libc = { version = "0.2", features = ["extra_traits"] }
 mach2 = "0.4"
-objc2 = "0.4.0"
+objc2 = "0.4"
 static_assertions = "1.1"
 
 # External - For tests


### PR DESCRIPTION
See https://github.com/HarfangLab/endpoint-sec/pull/7/files#r1280891213 for an instance of the problem