### PR TITLE
docs: add --generate-link-to-definition flag

### DIFF
--- a/endpoint-sec-sys/Cargo.toml
+++ b/endpoint-sec-sys/Cargo.toml
@@ -37,5 +37,5 @@ objc2.workspace = true
 
 [package.metadata.docs.rs]
 features = ["max"]
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 targets = ["x86_64-apple-darwin", "aarch64-apple-darwin"]

--- a/endpoint-sec/Cargo.toml
+++ b/endpoint-sec/Cargo.toml
@@ -43,5 +43,5 @@ sysinfo.workspace = true
 
 [package.metadata.docs.rs]
 features = ["max", "audit_token_from_pid"]
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 targets = ["x86_64-apple-darwin", "aarch64-apple-darwin"]


### PR DESCRIPTION
This enables "jump to definition" functionality in the
source code view of rustdoc.
