### PR TITLE
fix: better implementation of `Clone` for `ShouldNotBeNull`

### DIFF
--- a/endpoint-sec-sys/src/lib.rs
+++ b/endpoint-sec-sys/src/lib.rs
@@ -56,7 +56,7 @@ pub struct ShouldNotBeNull<T: ?Sized>(*mut T);
 impl<T: ?Sized> Clone for ShouldNotBeNull<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self(self.0)
+        *self
     }
 }
 


### PR DESCRIPTION
This lint came with the new Rust version
