### PR TITLE
feat: Don't require the closure passed to `Client` to be `'static`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bfc506e7a2370ec239e1d072507b2a80c833083699d3c6fa176fbb4de8448c6"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "block-sys"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "block2"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bb065b1ae91eaf6774e57c0e437f93b3111bac2d6011e517c72df84323e0a5"
+checksum = "15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68"
 dependencies = [
  "block-sys",
  "objc2",
@@ -97,6 +106,7 @@ dependencies = [
  "mach2",
  "static_assertions",
  "sysinfo",
+ "trybuild",
 ]
 
 [[package]]
@@ -110,6 +120,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +133,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "libc"
@@ -169,9 +191,9 @@ checksum = "99e1d07c6eab1ce8b6382b8e3c7246fe117ff3f8b34be065f5ebace6749fe845"
 
 [[package]]
 name = "objc2"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf6c364d54fa7b8be594c17b1506d5fe332038d3f6ef7b4ce36a5788798634c"
+checksum = "559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d"
 dependencies = [
  "objc-sys",
  "objc2-encode",
@@ -179,15 +201,33 @@ dependencies = [
 
 [[package]]
 name = "objc2-encode"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de517cb1d179b07c6c59fb4ce60f7511eba229a2488472bb41f00344d22a091e"
+checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
 
 [[package]]
 name = "once_cell"
 version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "rayon"
@@ -212,16 +252,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "serde"
+version = "1.0.188"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.188"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "syn"
+version = "2.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "sysinfo"
@@ -239,6 +327,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "196a58260a906cedb9bf6d8034b6379d0c11f552416960452f267402ceeddff1"
+dependencies = [
+ "basic-toml",
+ "glob",
+ "once_cell",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "termcolor",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +371,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ endpoint-sec = { version = "0.2.1", path = "./endpoint-sec" }
 endpoint-sec-sys = { version = "0.2.1", path = "./endpoint-sec-sys" }
 
 # External - Required
-block2 = "0.2"
+block2 = "0.3"
 libc = { version = "0.2", features = ["extra_traits"] }
 mach2 = "0.4"
 objc2 = "0.4"
@@ -24,3 +24,4 @@ static_assertions = "1.1"
 
 # External - For tests
 sysinfo = "0.28"
+trybuild = "1.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ test_script:
 # First, build all the tests
 - cargo nextest run --no-run --verbose --locked --offline --all-features
 # Then, add entitlement to all test binaries
-- find target/debug/deps -perm +111 -type f | xargs -I '{}' codesign -s - --entitlements endpoint-sec/Entitlement.plist --force {}
+- find target/debug/deps -perm +111 -type f | grep -v '\.dylib$' | xargs -I '{}' codesign -s - --entitlements endpoint-sec/Entitlement.plist --force {}
 # Now we can run them
 - sudo cargo nextest run --verbose --locked --offline --all-features
 

--- a/endpoint-sec/Cargo.toml
+++ b/endpoint-sec/Cargo.toml
@@ -38,8 +38,10 @@ mach2.workspace = true
 libc.workspace = true
 static_assertions.workspace = true
 
+
 [target.'cfg(target_os = "macos")'.dev-dependencies]
 sysinfo.workspace = true
+trybuild.workspace = true
 
 [package.metadata.docs.rs]
 features = ["max", "audit_token_from_pid"]

--- a/endpoint-sec/src/lib.rs
+++ b/endpoint-sec/src/lib.rs
@@ -32,6 +32,8 @@
 pub use endpoint_sec_sys as sys;
 #[cfg(all(test, not(feature = "audit_token_from_pid")))]
 use sysinfo as _;
+#[cfg(test)]
+use trybuild as _;
 
 /// Our wrappers around Endpoint Security events cannot easily implement [`Debug`]: they contain
 /// a reference to the original value (and sometimes the version). Since the structs behind the

--- a/endpoint-sec/tests/ui.rs
+++ b/endpoint-sec/tests/ui.rs
@@ -1,0 +1,11 @@
+//! Dummy libary used to separate trybuild since it is causing spurious recompilations because we change
+//! the binaries by signing them.
+
+#[cfg(all(test, not(feature = "test_trybuild_deactivate")))]
+mod tests {
+    #[test]
+    fn test_trybuild_client_ui() {
+        let t = trybuild::TestCases::new();
+        t.compile_fail("tests/ui/*.rs");
+    }
+}

--- a/endpoint-sec/tests/ui/test_client_cannot_outlive_handler.rs
+++ b/endpoint-sec/tests/ui/test_client_cannot_outlive_handler.rs
@@ -1,0 +1,15 @@
+use endpoint_sec::Client;
+
+fn main() {
+    let mut client = {
+        let v = vec![1, 2, 3];
+        let handler = |_: &mut Client<'_>, _| {
+            dbg!(&v);
+        };
+        let client = Client::new(handler).unwrap();
+
+        std::mem::drop(handler);
+        client
+    };
+    client.unsubscribe_all();
+}

--- a/endpoint-sec/tests/ui/test_client_cannot_outlive_handler.stderr
+++ b/endpoint-sec/tests/ui/test_client_cannot_outlive_handler.stderr
@@ -1,0 +1,13 @@
+error[E0597]: `v` does not live long enough
+  --> tests/ui/test_client_cannot_outlive_handler.rs:7:19
+   |
+4  |     let mut client = {
+   |         ---------- borrow later stored here
+5  |         let v = vec![1, 2, 3];
+6  |         let handler = |_: &mut Client<'_>, _| {
+   |                       ----------------------- value captured here
+7  |             dbg!(&v);
+   |                   ^ borrowed value does not live long enough
+...
+13 |     };
+   |     - `v` dropped here while still borrowed


### PR DESCRIPTION
This allows constructing a client locally and have it interact inside a `std::thread::scope` for example,
depending on non-`'static` data.

I added a trybuild test to ensure we don't allow the client to outlive the handler.

This is breaking change and will need a 0.3.0
