### PR TITLE
ci: Run with a smarter config to avoid double-runs for local branches

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,7 @@
 name: Build
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ env:
 
 on:
   push:
-    branches: ["**"]
+    branches: ["main"]
     tags-ignore: ["**"]
   pull_request:
 


### PR DESCRIPTION
- ci: Use better defined vars for concurrency detection
- ci: Only run branch CI on main, so that local dev branches don't run all jobs twice
