### PR TITLE
release: v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "endpoint-sec"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "endpoint-sec-sys",
  "libc",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "endpoint-sec-sys"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "block2",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 authors = ["HarfangLab Rust Team"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -12,8 +12,8 @@ resolver = "2"
 
 [workspace.dependencies]
 # In workspace
-endpoint-sec = { version = "0.2.1", path = "./endpoint-sec" }
-endpoint-sec-sys = { version = "0.2.1", path = "./endpoint-sec-sys" }
+endpoint-sec = { version = "0.3.0", path = "./endpoint-sec" }
+endpoint-sec-sys = { version = "0.3.0", path = "./endpoint-sec-sys" }
 
 # External - Required
 block2 = "0.3"

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,8 @@
+default:
+    just --list
+
+# `cargo publish`, with `--dry-run` by default, use `just publish ""` to actually do it.
+publish arg="--dry-run":
+    git describe --exact-match --tags $(git log -n1 --pretty='%h')
+    cargo publish {{ arg }} -p endpoint-sec-sys
+    cargo publish {{ arg }} -p endpoint-sec

--- a/endpoint-sec/tests/ui/test_client_cannot_be_smuggled_out.rs
+++ b/endpoint-sec/tests/ui/test_client_cannot_be_smuggled_out.rs
@@ -1,0 +1,15 @@
+fn main() {
+    use std::cell::RefCell;
+
+    use endpoint_sec::Client;
+
+    Client::new(|client, _| {
+        let other_client = Client::new(|_, _| {}).unwrap();
+        // Tear the `client` out of the `&mut` reference.
+        let smuggled_client = std::mem::replace(client, other_client);
+        thread_local! {
+            static CLIENT_SMUGGLING: RefCell<Option<Client<'static>>> = RefCell::new(None);
+        }
+        CLIENT_SMUGGLING.with(|r| *r.borrow_mut() = Some(smuggled_client));
+    });
+}

--- a/endpoint-sec/tests/ui/test_client_cannot_be_smuggled_out.stderr
+++ b/endpoint-sec/tests/ui/test_client_cannot_be_smuggled_out.stderr
@@ -1,0 +1,18 @@
+error[E0521]: borrowed data escapes outside of closure
+  --> tests/ui/test_client_cannot_be_smuggled_out.rs:13:9
+   |
+6  |     Client::new(|client, _| {
+   |                  ------
+   |                  |
+   |                  `client` is a reference that is only valid in the closure body
+   |                  has type `&mut Client<'1>`
+...
+13 |         CLIENT_SMUGGLING.with(|r| *r.borrow_mut() = Some(smuggled_client));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         `client` escapes the closure body here
+   |         argument requires that `'1` must outlive `'static`
+   |
+   = note: requirement occurs because of the type `RefCell<Option<Client<'_>>>`, which makes the generic argument `Option<Client<'_>>` invariant
+   = note: the struct `RefCell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance


### PR DESCRIPTION
- tests: add compile test to ensure `Client`s cannot be swapped
- release: Add Justfile to help with publishing
- release: version 0.3.0
