### PR TITLE
fix: Extend lifetime for objects that were unnecessarily restrained to that of `&self`

### DIFF
--- a/endpoint-sec/src/event/event_close.rs
+++ b/endpoint-sec/src/event/event_close.rs
@@ -22,7 +22,7 @@ impl<'a> EventClose<'a> {
 
     /// The file that is being closed.
     #[inline(always)]
-    pub fn target(&self) -> File<'_> {
+    pub fn target(&self) -> File<'a> {
         // Safety: 'a tied to self, object obtained through ES
         File::new(unsafe { self.raw.target() })
     }

--- a/endpoint-sec/src/event/event_exchangedata.rs
+++ b/endpoint-sec/src/event/event_exchangedata.rs
@@ -14,14 +14,14 @@ pub struct EventExchangeData<'a> {
 impl<'a> EventExchangeData<'a> {
     /// The first file to be exchanged.
     #[inline(always)]
-    pub fn file1(&self) -> File<'_> {
+    pub fn file1(&self) -> File<'a> {
         // Safety: 'a tied to self, object obtained through ES
         File::new(unsafe { self.raw.file1() })
     }
 
     /// The second file to be exchanged.
     #[inline(always)]
-    pub fn file2(&self) -> File<'_> {
+    pub fn file2(&self) -> File<'a> {
         // Safety: 'a tied to self, object obtained through ES
         File::new(unsafe { self.raw.file2() })
     }

--- a/endpoint-sec/src/event/event_exec.rs
+++ b/endpoint-sec/src/event/event_exec.rs
@@ -6,8 +6,7 @@ use std::iter::FusedIterator;
 #[cfg(feature = "macos_13_0_0")]
 use endpoint_sec_sys::{cpu_subtype_t, cpu_type_t};
 use endpoint_sec_sys::{
-    es_event_exec_t, es_exec_arg, es_exec_arg_count, es_exec_env, es_exec_env_count,
-    es_string_token_t,
+    es_event_exec_t, es_exec_arg, es_exec_arg_count, es_exec_env, es_exec_env_count, es_string_token_t,
 };
 #[cfg(feature = "macos_11_0_0")]
 use endpoint_sec_sys::{es_exec_fd, es_exec_fd_count, es_fd_t, ShouldNotBeNull};
@@ -34,7 +33,7 @@ pub struct Fd<'a>(pub(crate) &'a es_fd_t);
 impl<'a> EventExec<'a> {
     /// The new process that is being executed.
     #[inline(always)]
-    pub fn target(&self) -> Process<'_> {
+    pub fn target(&self) -> Process<'a> {
         // Safety: 'a tied to self, object obtained through ES
         Process::new(unsafe { self.raw.target() }, self.version)
     }
@@ -61,7 +60,7 @@ impl<'a> EventExec<'a> {
     /// interpreter (e.g. `./foo.sh` not `/bin/sh ./foo.sh`)
     #[cfg(feature = "macos_10_15_1")]
     #[inline(always)]
-    pub fn script(&self) -> Option<File<'_>> {
+    pub fn script(&self) -> Option<File<'a>> {
         if self.version >= 2 {
             // Safety: Safe as we check the version before accessing the field.
             let script_ptr = unsafe { self.raw.anon_0.anon_0.script };
@@ -77,7 +76,7 @@ impl<'a> EventExec<'a> {
     /// Current working directory at exec time (if present) on version 3 and later, otherwise None.
     #[inline(always)]
     #[cfg(feature = "macos_10_15_4")]
-    pub fn cwd(&self) -> Option<File<'_>> {
+    pub fn cwd(&self) -> Option<File<'a>> {
         if self.version >= 3 {
             // Safety: Safe as File cannot outlive self and as we check the version before accessing the field.
             Some(File::new(unsafe { self.raw.anon_0.anon_0.cwd.as_ref() }))

--- a/endpoint-sec/src/event/event_file_provider_materialize.rs
+++ b/endpoint-sec/src/event/event_file_provider_materialize.rs
@@ -17,7 +17,7 @@ pub struct EventFileProviderMaterialize<'a> {
 impl<'a> EventFileProviderMaterialize<'a> {
     /// The process that instigated the materialization.
     #[inline(always)]
-    pub fn instigator(&self) -> Process<'_> {
+    pub fn instigator(&self) -> Process<'a> {
         // Safety: 'a tied to self, object obtained through ES
         Process::new(unsafe { self.raw.instigator() }, self.version)
     }

--- a/endpoint-sec/src/event/event_fork.rs
+++ b/endpoint-sec/src/event/event_fork.rs
@@ -17,7 +17,7 @@ pub struct EventFork<'a> {
 impl<'a> EventFork<'a> {
     /// The child process that was created.
     #[inline(always)]
-    pub fn child(&self) -> Process<'_> {
+    pub fn child(&self) -> Process<'a> {
         // Safety: 'a tied to self, object obtained through ES
         Process::new(unsafe { self.raw.child() }, self.version)
     }

--- a/endpoint-sec/src/event/event_get_task.rs
+++ b/endpoint-sec/src/event/event_get_task.rs
@@ -27,7 +27,7 @@ impl<'a> EventGetTask<'a> {
 
     /// The process for which the task control port will be retrieved.
     #[inline(always)]
-    pub fn target(&self) -> Process<'_> {
+    pub fn target(&self) -> Process<'a> {
         // Safety: 'a tied to self, object obtained through ES
         Process::new(unsafe { self.raw.target() }, self.version)
     }

--- a/endpoint-sec/src/event/event_mmap.rs
+++ b/endpoint-sec/src/event/event_mmap.rs
@@ -38,7 +38,7 @@ impl<'a> EventMmap<'a> {
 
     /// The file system object being mapped.
     #[inline(always)]
-    pub fn source(&self) -> File<'_> {
+    pub fn source(&self) -> File<'a> {
         // Safety: 'a tied to self, object obtained through ES
         File::new(unsafe { self.raw.source() })
     }

--- a/endpoint-sec/src/event/event_open.rs
+++ b/endpoint-sec/src/event/event_open.rs
@@ -20,7 +20,7 @@ impl<'a> EventOpen<'a> {
 
     /// The file that will be opened.
     #[inline(always)]
-    pub fn file(&self) -> File<'_> {
+    pub fn file(&self) -> File<'a> {
         // Safety: 'a tied to self, object obtained through ES
         File::new(unsafe { self.raw.file() })
     }

--- a/endpoint-sec/src/event/event_signal.rs
+++ b/endpoint-sec/src/event/event_signal.rs
@@ -23,7 +23,7 @@ impl<'a> EventSignal<'a> {
 
     /// The process that will receive the signal.
     #[inline(always)]
-    pub fn target(&self) -> Process<'_> {
+    pub fn target(&self) -> Process<'a> {
         // Safety: 'a tied to self, object obtained through ES
         Process::new(unsafe { self.raw.target() }, self.version)
     }

--- a/endpoint-sec/src/event/event_trace.rs
+++ b/endpoint-sec/src/event/event_trace.rs
@@ -17,7 +17,7 @@ pub struct EventTrace<'a> {
 impl<'a> EventTrace<'a> {
     /// The process that will be attached to by the process that instigated the event.
     #[inline(always)]
-    pub fn target(&self) -> Process<'_> {
+    pub fn target(&self) -> Process<'a> {
         // Safety: 'a tied to self, object obtained through ES
         Process::new(unsafe { self.raw.target() }, self.version)
     }

--- a/endpoint-sec/src/event/event_unlink.rs
+++ b/endpoint-sec/src/event/event_unlink.rs
@@ -14,14 +14,14 @@ pub struct EventUnlink<'a> {
 impl<'a> EventUnlink<'a> {
     /// The object that will be removed.
     #[inline(always)]
-    pub fn target(&self) -> File<'_> {
+    pub fn target(&self) -> File<'a> {
         // Safety: 'a tied to self, object obtained through ES
         File::new(unsafe { self.raw.target() })
     }
 
     /// The parent directory of the `target` file system object.
     #[inline(always)]
-    pub fn parent_dir(&self) -> File<'_> {
+    pub fn parent_dir(&self) -> File<'a> {
         // Safety: 'a tied to self, object obtained through ES
         File::new(unsafe { self.raw.parent_dir() })
     }


### PR DESCRIPTION
A quick fix for objects that were restrained to the lifetime of their event's `&self` instead of the (wider) lifetime of the whole `Message`.

I'll publish a new version `0.3.1` just after, since it's not a breaking change I think: lifetimes are wider, nothing that was possible before is impossible now.
