### PR TITLE
Avoid freeing block_handler too early

### DIFF
--- a/endpoint-sec/tests/client.rs
+++ b/endpoint-sec/tests/client.rs
@@ -7,3 +7,28 @@ fn test_client_can_connect() {
     })
     .unwrap();
 }
+
+#[test]
+fn reproduce_double_drop() {
+    #[derive(Debug)]
+    struct DropCnt {
+        // To avoid segfaulting in case we regress, we leak the allocation here.
+        cnt: std::mem::ManuallyDrop<Box<u32>>,
+    }
+    impl Drop for DropCnt {
+        fn drop(&mut self) {
+            println!("Dropping, counter at {}", **self.cnt);
+            **self.cnt += 1;
+            if **self.cnt > 1 {
+                panic!("Dropped more than once");
+            }
+        }
+    }
+    let drop_cnt = DropCnt {
+        cnt: std::mem::ManuallyDrop::new(Box::new(0)),
+    };
+    Client::new(move |_client, _msg| {
+        println!("{:?}", drop_cnt);
+    })
+    .unwrap();
+}


### PR DESCRIPTION
Client::new would automatically free the block_handler, which would also free the closure. This was initially thought to be fine as es_new_client should be cloning the block. However, the ConcreteBlock implementation of copy does not actually do a deep clone - instead it merely does a memmove of the closure data.

As such, we need to make sure we don't run the destructore on block_handler.