### PR TITLE
Fix UB on EventSu::to_uid

### DIFF
--- a/endpoint-sec/src/event/event_login_login.rs
+++ b/endpoint-sec/src/event/event_login_login.rs
@@ -42,7 +42,7 @@ impl<'a> EventLoginLogin<'a> {
     #[inline(always)]
     pub fn uid(&self) -> Option<uid_t> {
         // Safety: access is gated on documented conditions
-        self.has_uid().then_some(unsafe { self.raw.anon0.uid })
+        self.has_uid().then(|| unsafe { self.raw.anon0.uid })
     }
 }
 

--- a/endpoint-sec/src/event/event_openssh_login.rs
+++ b/endpoint-sec/src/event/event_openssh_login.rs
@@ -58,7 +58,7 @@ impl<'a> EventOpensshLogin<'a> {
     #[inline(always)]
     pub fn uid(&self) -> Option<uid_t> {
         // Safety: access is gated on documented conditions
-        self.has_uid().then_some(unsafe { self.raw.anon0.uid })
+        self.has_uid().then(|| unsafe { self.raw.anon0.uid })
     }
 
     /// Source address as an [`IpAddr`] from the standard library, if possible.

--- a/endpoint-sec/src/event/event_su.rs
+++ b/endpoint-sec/src/event/event_su.rs
@@ -52,7 +52,7 @@ impl<'a> EventSu<'a> {
     #[inline(always)]
     pub fn to_uid(&self) -> Option<uid_t> {
         // Safety: checked for success and `has_to_uid`
-        (self.success() && self.has_to_uid()).then_some(unsafe { self.raw.to_uid.uid })
+        (self.success() && self.has_to_uid()).then(|| unsafe { self.raw.to_uid.uid })
     }
 
     /// If success, the user name that is going to be substituted

--- a/endpoint-sec/src/event/event_sudo.rs
+++ b/endpoint-sec/src/event/event_sudo.rs
@@ -39,7 +39,7 @@ impl<'a> EventSudo<'a> {
     #[inline(always)]
     pub fn from_uid(&self) -> Option<uid_t> {
         // Safety: 'a tied to self, object obtained through ES
-        self.has_from_uid().then_some(unsafe { self.raw.from_uid.uid })
+        self.has_from_uid().then(|| unsafe { self.raw.from_uid.uid })
     }
     /// Optional. The name of the user who initiated the su
     #[inline(always)]
@@ -59,7 +59,7 @@ impl<'a> EventSudo<'a> {
             return None;
         }
         // Safety: 'a tied to self, object obtained through ES
-        self.has_to_uid().then_some(unsafe { self.raw.to_uid.uid })
+        self.has_to_uid().then(|| unsafe { self.raw.to_uid.uid })
     }
     /// Optional. If success, the user name that is going to be substituted
     #[inline(always)]


### PR DESCRIPTION
tldr: the code inside bool::then_some is always executed, but the code in the closure from bool::then is only executed if is true.

This is UB, because the bool::then_some is a function that takes a bool and a generic value, because of that, the value inside of it is always evaluated, independent if the bool is true/false.

it's clear if the desugarize the syntax:

```rust
// first we get the true/false for the condition
let cond: bool = self.success() && self.has_to_uid();
// then we evaluate the expression to pass the value as parameter
// UB here, the is executed always, independent of the cond being true/false
let value = unsafe { self.raw.to_uid.uid };
// then we call the function `bool::then_some`.
bool::then_some(cond, value)
```

The solution is simply change it to bool::then, because the parameter it's a closure, it's lazy evaluated, and only executed if the condition is true.

As mentioned at https://github.com/rust-lang/rust/blob/5cb2e7dfc362662b0036faad3bab88d73027fd05/src/tools/clippy/clippy_lints/src/transmute/mod.rs#L468-L520

And presented at https://youtu.be/hBjQ3HqCfxs?si=nrIz6ZHnxEHO6Pik&t=53
