### PR TITLE
Fix segfault when using default feature

### DIFF
--- a/endpoint-sec-sys/src/message.rs
+++ b/endpoint-sec-sys/src/message.rs
@@ -3100,7 +3100,6 @@ pub struct es_message_t {
     /// See `global_seq_num`.
     ///
     /// Field available only if message version >= 2.
-    #[cfg(feature = "macos_10_15_1")]
     pub seq_num: u64,
     /// Indicates if the action field is an auth or notify action
     pub action_type: es_action_type_t,


### PR DESCRIPTION
When using the default feature, the FFI structure for es_message_t was wrong (a field in the middle was cfg'd out, causing everything to be offset by 8 bytes).

To fix this issue, we simply remove the wrong cfg, fixing the es_message_t structure.

Fixes #33 

I did a quick review of the other structures, but they seem to be OK, all the cfgs are at the end, and always ordered from oldest to newest.

Note that I did not change the seq_num() accessor, which is cfg'd to be accessible only on macos_10_15_4+. I think that's correct enough.