### PR TITLE
Release 0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "endpoint-sec"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "endpoint-sec-sys",
  "libc",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "endpoint-sec-sys"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "block2",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 authors = ["HarfangLab Rust Team"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -12,8 +12,8 @@ resolver = "2"
 
 [workspace.dependencies]
 # In workspace
-endpoint-sec = { version = "0.3.3", path = "./endpoint-sec" }
-endpoint-sec-sys = { version = "0.3.3", path = "./endpoint-sec-sys" }
+endpoint-sec = { version = "0.3.4", path = "./endpoint-sec" }
+endpoint-sec-sys = { version = "0.3.4", path = "./endpoint-sec-sys" }
 
 # External - Required
 block2 = "0.3"


### PR DESCRIPTION
Changes:
- Fix segfault when using default feature due to broken FFI definition of `es_message_t`.

Commit list: [v0.3.3..release-0.3.4](https://github.com/HarfangLab/endpoint-sec/compare/v0.3.3...roblabla:endpoint-sec:release-0.3.4)