### PR TITLE
ci: use the macos 14 runner

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -158,7 +158,7 @@ jobs:
         - { version: "11", feature: macos_11_3_0 }
         - { version: "12", feature: macos_12_0_0 }
         - { version: "13", feature: macos_13_3_0 }
-        - { version: "13", feature: macos_14_0_0 } # no macOS 14 runner for github yet
+        - { version: "14", feature: macos_14_0_0 }
 
     steps:
       - name: checkout sources

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # Build image
-image: macos-monterey
+image: macos-sonoma
 
 install:
 # Install rustup


### PR DESCRIPTION
I submit this PR to use the latest macOS 14 runner in CI 