### PR TITLE
Chore(deps): Bump block2 and objc2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,21 +9,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "block-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dd7cf50912cddc06dc5ea7c08c5e81c1b2c842a70d19def1848d54c586fed92"
-dependencies = [
- "objc-sys",
-]
-
-[[package]]
 name = "block2"
-version = "0.3.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "block-sys",
  "objc2",
 ]
 
@@ -204,15 +194,15 @@ dependencies = [
 
 [[package]]
 name = "objc-sys"
-version = "0.3.1"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e1d07c6eab1ce8b6382b8e3c7246fe117ff3f8b34be065f5ebace6749fe845"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
 
 [[package]]
 name = "objc2"
-version = "0.4.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
 dependencies = [
  "objc-sys",
  "objc2-encode",
@@ -220,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "objc2-encode"
-version = "3.0.0"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
+checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
 
 [[package]]
 name = "once_cell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ endpoint-sec = { version = "0.3.4", path = "./endpoint-sec" }
 endpoint-sec-sys = { version = "0.3.4", path = "./endpoint-sec-sys" }
 
 # External - Required
-block2 = "0.3"
+block2 = "0.5"
 libc = { version = "0.2", features = ["extra_traits"] }
 mach2 = "0.4"
-objc2 = "0.4"
+objc2 = "0.5"
 static_assertions = "1.1"
 
 # External - For tests

--- a/endpoint-sec-sys/src/client.rs
+++ b/endpoint-sec-sys/src/client.rs
@@ -604,7 +604,7 @@ extern "C" {
 ///  "respond" functions
 /// - The `es_message_t` is the message that must be handled. Mutating it is forbidden but Rust
 ///  does not expose a `ConstNonNull` type.
-pub type es_handler_block_t = Block<(NonNull<es_client_t>, NonNull<es_message_t>), ()>;
+pub type es_handler_block_t<'f> = Block<dyn Fn(NonNull<es_client_t>, NonNull<es_message_t>) + 'f>;
 
 #[link(name = "EndpointSecurity", kind = "dylib")]
 extern "C" {


### PR DESCRIPTION
Bumps both to their respective latest version.

Special care should be taken reviewing this one in particular:
 * `Block` transitioned from taking two type arguments in the form of `<(In1, In2, ...), Out>` to a single `dyn` one: `<dyn Fn(In1, In2, ...) -> Out>`. A lifetime can be added to this, making the block non-`'static`. This was required for `endpoint_sec_sys::client::es_handler_block_t`, which could be a breaking change. However, it is not in `endpoint-sec` since inference succeeds there.
 * `ConcreteBlock` was renamed to `StackBlock` and now requires the passed function to be `Clone`, which in our single use of it was too restrictive for callers and would have required changing tests accordingly so that all types involved in the given function be `Clone` as well. In order to avoid that and as recommended by [`block2`'s documentation](https://docs.rs/block2/latest/block2/struct.StackBlock.html#method.new), this replaces `StackBlock` with `RcBlock` that does not require the function to be `Clone`. As a secondary consequence, the use of `ManuallyDrop` was removed for reasons explained in the added safety comments: that is the main point of concern here. The CI tests did not need to be changed for this and do not show any leakage, so it should be good?