### PR TITLE
Chore(test): Update UI fixtures

### DIFF
--- a/endpoint-sec/tests/ui/test_client_cannot_be_smuggled_out.stderr
+++ b/endpoint-sec/tests/ui/test_client_cannot_be_smuggled_out.stderr
@@ -1,18 +1,18 @@
 error[E0521]: borrowed data escapes outside of closure
-  --> tests/ui/test_client_cannot_be_smuggled_out.rs:13:9
-   |
-6  |     Client::new(|client, _| {
-   |                  ------
-   |                  |
-   |                  `client` is a reference that is only valid in the closure body
-   |                  has type `&mut Client<'1>`
+ --> tests/ui/test_client_cannot_be_smuggled_out.rs:9:31
+  |
+6 |     Client::new(|client, _| {
+  |                  ------
+  |                  |
+  |                  `client` is a reference that is only valid in the closure body
+  |                  has type `&mut Client<'1>`
 ...
-13 |         CLIENT_SMUGGLING.with(|r| *r.borrow_mut() = Some(smuggled_client));
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |         |
-   |         `client` escapes the closure body here
-   |         argument requires that `'1` must outlive `'static`
-   |
-   = note: requirement occurs because of the type `RefCell<Option<Client<'_>>>`, which makes the generic argument `Option<Client<'_>>` invariant
-   = note: the struct `RefCell<T>` is invariant over the parameter `T`
-   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+9 |         let smuggled_client = std::mem::replace(client, other_client);
+  |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                               |
+  |                               `client` escapes the closure body here
+  |                               argument requires that `'1` must outlive `'static`
+  |
+  = note: requirement occurs because of a mutable reference to `Client<'_>`
+  = note: mutable references are invariant over their type parameter
+  = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance

--- a/endpoint-sec/tests/ui/test_client_cannot_outlive_handler.stderr
+++ b/endpoint-sec/tests/ui/test_client_cannot_outlive_handler.stderr
@@ -4,6 +4,7 @@ error[E0597]: `v` does not live long enough
 4  |     let mut client = {
    |         ---------- borrow later stored here
 5  |         let v = vec![1, 2, 3];
+   |             - binding `v` declared here
 6  |         let handler = |_: &mut Client<'_>, _| {
    |                       ----------------------- value captured here
 7  |             dbg!(&v);


### PR DESCRIPTION
This should help fix the current build status on `main`. The changes seem to only be due to the more recent Rust versions, but the core of the errors is still there.