### PR TITLE
CI: Enforce clippy

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,7 +62,9 @@ jobs:
             --all-targets \
             --target x86_64-apple-darwin \
             --target aarch64-apple-darwin \
-            --features ${{ matrix.feature }}
+            --features ${{ matrix.feature }} \
+            -- \
+            -D warnings
 
   clippy-all-features:
     name: Clippy - all features (${{ matrix.version.name }})
@@ -101,7 +103,9 @@ jobs:
             --all-targets \
             --target x86_64-apple-darwin \
             --target aarch64-apple-darwin \
-            --all-features
+            --all-features \
+            -- \
+            -D warnings
 
   build-all-features:
     name: Build - all features (${{ matrix.version.name }})

--- a/endpoint-sec-sys/src/lib.rs
+++ b/endpoint-sec-sys/src/lib.rs
@@ -42,7 +42,7 @@
     rustdoc::broken_intra_doc_links
 )]
 
-use core::fmt;
+use core::{fmt, ptr};
 
 /// A wrapper type around `*mut T` to communicate a pointer should not be null without introducing
 /// undefined behaviour.
@@ -125,7 +125,7 @@ impl<T: ?Sized> Eq for ShouldNotBeNull<T> {}
 impl<T: ?Sized> PartialEq for ShouldNotBeNull<T> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.as_ptr() == other.as_ptr()
+        ptr::eq(self.as_ptr(), other.as_ptr())
     }
 }
 

--- a/endpoint-sec/src/acl.rs
+++ b/endpoint-sec/src/acl.rs
@@ -10,7 +10,7 @@ use endpoint_sec_sys::{_acl, acl_t};
 // TODO: correctly implement Debug/Eq/Hash for ACLs
 #[doc(alias = "acl_t")]
 #[doc(alias = "_acl")]
-pub struct Acl<'a>(&'a _acl);
+pub struct Acl<'a>(#[allow(unused)] &'a _acl);
 
 impl<'a> Acl<'a> {
     /// Builds an ACL wrapper from the raw one.

--- a/endpoint-sec/src/event/event_login_login.rs
+++ b/endpoint-sec/src/event/event_login_login.rs
@@ -42,6 +42,7 @@ impl<'a> EventLoginLogin<'a> {
     #[inline(always)]
     pub fn uid(&self) -> Option<uid_t> {
         // Safety: access is gated on documented conditions
+        #[allow(clippy::unnecessary_lazy_evaluations)]
         self.has_uid().then(|| unsafe { self.raw.anon0.uid })
     }
 }

--- a/endpoint-sec/src/event/event_openssh_login.rs
+++ b/endpoint-sec/src/event/event_openssh_login.rs
@@ -58,6 +58,7 @@ impl<'a> EventOpensshLogin<'a> {
     #[inline(always)]
     pub fn uid(&self) -> Option<uid_t> {
         // Safety: access is gated on documented conditions
+        #[allow(clippy::unnecessary_lazy_evaluations)]
         self.has_uid().then(|| unsafe { self.raw.anon0.uid })
     }
 

--- a/endpoint-sec/src/event/event_su.rs
+++ b/endpoint-sec/src/event/event_su.rs
@@ -52,6 +52,7 @@ impl<'a> EventSu<'a> {
     #[inline(always)]
     pub fn to_uid(&self) -> Option<uid_t> {
         // Safety: checked for success and `has_to_uid`
+        #[allow(clippy::unnecessary_lazy_evaluations)]
         (self.success() && self.has_to_uid()).then(|| unsafe { self.raw.to_uid.uid })
     }
 

--- a/endpoint-sec/src/event/event_sudo.rs
+++ b/endpoint-sec/src/event/event_sudo.rs
@@ -39,6 +39,7 @@ impl<'a> EventSudo<'a> {
     #[inline(always)]
     pub fn from_uid(&self) -> Option<uid_t> {
         // Safety: 'a tied to self, object obtained through ES
+        #[allow(clippy::unnecessary_lazy_evaluations)]
         self.has_from_uid().then(|| unsafe { self.raw.from_uid.uid })
     }
     /// Optional. The name of the user who initiated the su
@@ -59,6 +60,7 @@ impl<'a> EventSudo<'a> {
             return None;
         }
         // Safety: 'a tied to self, object obtained through ES
+        #[allow(clippy::unnecessary_lazy_evaluations)]
         self.has_to_uid().then(|| unsafe { self.raw.to_uid.uid })
     }
     /// Optional. If success, the user name that is going to be substituted


### PR DESCRIPTION
Currently, Clippy in only ran in CI to fail on errors, not on warnings, which is not ideal. This therefore fixes warnings currently triggered on `main` and adds `-D warnings` to the CI execution of Clippy in order to enforce warnings in the future.