### PR TITLE
Fix warnings

### DIFF
--- a/endpoint-sec-sys/src/additional.rs
+++ b/endpoint-sec-sys/src/additional.rs
@@ -123,16 +123,16 @@ extern "C" {
     /// - `atoken`: the audit token containing the desired information
     /// - `auidp`: Pointer to a `uid_t`; on return will be set to the task or sender's audit user ID
     /// - `euidp`: Pointer to a `uid_t`; on return will be set to the task or sender's effective
-    ///  user ID
+    ///   user ID
     /// - `egidp`: Pointer to a `gid_t`; on return will be set to the task or sender's effective
-    ///  group ID
+    ///   group ID
     /// - `ruidp`: Pointer to a `uid_t`; on return will be set to the task or sender's real user ID
     /// - `rgidp`: Pointer to a `gid_t`; on return will be set to the task or sender's real group ID
     /// - `pidp`: Pointer to a `pid_t`; on return will be set to the task or sender's process ID
     /// - `asidp`: Pointer to an `au_asid_t`; on return will be set to the task or sender's audit
-    /// session ID
+    ///   session ID
     /// - `tidp`: Pointer to an `au_tid_t`; on return will be set to the process ID version and NOT
-    ///  THE SENDER'S TERMINAL ID.
+    ///   THE SENDER'S TERMINAL ID.
     ///
     /// IMPORTANT: In Apple's `bsm-8`, these are marked `__APPLE_API_PRIVATE`.
     pub fn audit_token_to_au32(

--- a/endpoint-sec-sys/src/client.rs
+++ b/endpoint-sec-sys/src/client.rs
@@ -199,7 +199,7 @@ extern "C" {
     ///
     /// - `client`: The es_client_t for which the muted processes will be retrieved.
     /// - `muted_processes`: OUT param the will contain newly created memory describing the set of
-    ///  muted processes. This memory must be deleted using [`es_release_muted_processes`].
+    ///   muted processes. This memory must be deleted using [`es_release_muted_processes`].
     ///
     /// See [`es_release_muted_processes()`]
     #[cfg(feature = "macos_12_0_0")]
@@ -462,7 +462,7 @@ extern "C" {
     ///
     /// - `client`: The es_client_t for which the muted paths will be retrieved.
     /// - `muted_paths`: OUT param the will contain newly created memory describing the set of
-    ///  muted paths. This memory must be deleted using [`es_release_muted_paths()`].
+    ///   muted paths. This memory must be deleted using [`es_release_muted_paths()`].
     ///
     /// See [`es_release_muted_paths()`]
     #[cfg(feature = "macos_12_0_0")]
@@ -601,9 +601,9 @@ extern "C" {
 /// The type of block that will be invoked to handled messages from the ES subsystem
 ///
 /// - The `es_client_t` is a handle to the client being sent the event. It must be passed to any
-///  "respond" functions
+///   "respond" functions
 /// - The `es_message_t` is the message that must be handled. Mutating it is forbidden but Rust
-///  does not expose a `ConstNonNull` type.
+///   does not expose a `ConstNonNull` type.
 pub type es_handler_block_t<'f> = Block<dyn Fn(NonNull<es_client_t>, NonNull<es_message_t>) + 'f>;
 
 #[link(name = "EndpointSecurity", kind = "dylib")]

--- a/endpoint-sec/tests/ui.rs
+++ b/endpoint-sec/tests/ui.rs
@@ -1,7 +1,7 @@
 //! Dummy libary used to separate trybuild since it is causing spurious recompilations because we change
 //! the binaries by signing them.
 
-#[cfg(all(test, not(feature = "test_trybuild_deactivate")))]
+#[cfg(test)]
 mod tests {
     #[test]
     fn test_trybuild_client_ui() {


### PR DESCRIPTION
Unblock the CI:
 * Remove the non-existent feature `cfg` gate.
 * Fix the recent `clippy::doc_lazy_continuation` by adding the few missing indentations.