### PR TITLE
CI: Bump macOS runners to at least v12

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -155,11 +155,12 @@ jobs:
         # Only build older macOS on the MSRV, since that's the likely use case
         - { name: MSRV, value: "1.70.0" }
         os:
-        # There are no 10.15 runners anymore
-        # To avoid reaching the Github Actions limits, we only test for the latest version of Endpoint
-        # Security on the OS version, e.g. 11.3 for macOS 11
-        - { version: "11", feature: macos_10_15_4 }
-        - { version: "11", feature: macos_11_3_0 }
+        # There are no 10.15 nor 11.3 runners anymore.
+        # To avoid reaching the Github Actions limits, we only test for the
+        # latest version of Endpoint Security on the OS version, e.g. 13.3 for
+        # macOS 13.
+        - { version: "12", feature: macos_10_15_4 }
+        - { version: "12", feature: macos_11_3_0 }
         - { version: "12", feature: macos_12_0_0 }
         - { version: "13", feature: macos_13_3_0 }
         - { version: "14", feature: macos_14_0_0 }


### PR DESCRIPTION
macOS 11 is not supported by [GitHub Actions](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) anymore. Therefore, make the jobs that used to run on 11 run on 12 instead. It should finally unblock the CI this time.