### PR TITLE
Mark enums (and some variants) as non_exhaustive.

### DIFF
--- a/endpoint-sec/src/event.rs
+++ b/endpoint-sec/src/event.rs
@@ -71,6 +71,7 @@ macro_rules! define_event_enum {
 define_event_enum!(
     /// Information related to an event.
     #[derive(Debug, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
     pub enum Event from (raw_event, version) {
         /// Authorization request for a process execution.
         ES_EVENT_TYPE_AUTH_EXEC => AuthExec(EventExec [_ => Some(ExpectedResponseType::Auth) ] { raw: &raw_event.exec, version, }),

--- a/endpoint-sec/src/event/event_authentication.rs
+++ b/endpoint-sec/src/event/event_authentication.rs
@@ -85,6 +85,7 @@ impl_debug_eq_hash_with_functions!(EventAuthentication<'a>; success, type_, data
 #[doc(alias = "es_event_authentication_t_anon0")]
 #[doc(alias = "es_authentication_type_t")]
 #[derive(Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum AuthenticationData<'a> {
     /// Wrapped [`es_event_authentication_t_anon_0.od`]
     Od(EventAuthenticationOd<'a>),

--- a/endpoint-sec/src/event/event_create.rs
+++ b/endpoint-sec/src/event/event_create.rs
@@ -20,12 +20,18 @@ pub struct EventCreate<'a> {
 /// Represent a destination file for [`EventCreate`].
 #[derive(Debug, PartialEq, Eq, Hash)]
 #[doc(alias = "es_destination_type_t")]
+#[non_exhaustive]
 pub enum EventCreateDestinationFile<'a> {
     /// The destination file already exist at the time of the event.
-    ExistingFile(File<'a>),
+    #[non_exhaustive]
+    ExistingFile {
+        /// The file that will be overwritten by the file creation.
+        file: File<'a>,
+    },
     /// The destination doesn't exist at the time of the event.
+    #[non_exhaustive]
     NewPath {
-        /// The directory into which the file will be renamed.
+        /// The directory into which the file will be created.
         directory: File<'a>,
         /// The name of the new file that will be created.
         filename: &'a OsStr,
@@ -40,10 +46,10 @@ impl<'a> EventCreate<'a> {
     pub fn destination(&self) -> Option<EventCreateDestinationFile<'a>> {
         match self.raw.destination_type {
             es_destination_type_t::ES_DESTINATION_TYPE_EXISTING_FILE => {
-                Some(EventCreateDestinationFile::ExistingFile(
+                Some(EventCreateDestinationFile::ExistingFile {
                     // Safety: Safe as we select the union field corresponding to that type.
-                    File::new(unsafe { self.raw.destination.existing_file.as_ref() }),
-                ))
+                    file: File::new(unsafe { self.raw.destination.existing_file.as_ref() }),
+                })
             },
             es_destination_type_t::ES_DESTINATION_TYPE_NEW_PATH => {
                 // Safety: Safe as we select the union fields corresponding to that type.

--- a/endpoint-sec/src/event/event_od_group_add.rs
+++ b/endpoint-sec/src/event/event_od_group_add.rs
@@ -141,6 +141,7 @@ impl_debug_eq_hash_with_functions!(OdMemberId<'a>; member_type, member_value);
 
 /// A member identity.
 #[derive(Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum OdMemberIdValue<'a> {
     /// Group member is a user, designated by name
     UserName(&'a OsStr),

--- a/endpoint-sec/src/event/event_od_group_set.rs
+++ b/endpoint-sec/src/event/event_od_group_set.rs
@@ -141,6 +141,7 @@ unsafe impl Send for OdMemberIdArray<'_> {}
 impl_debug_eq_hash_with_functions!(OdMemberIdArray<'a>; member_type, member_count);
 
 /// One of the possible iterator for [`OdMemberIdArray`]
+#[non_exhaustive]
 pub enum OdMemberIdArrayIters<'arr, 'raw> {
     /// Users, designated by name
     UserName(OdMemberIdArrayNames<'arr, 'raw>),

--- a/endpoint-sec/src/event/event_rename.rs
+++ b/endpoint-sec/src/event/event_rename.rs
@@ -16,14 +16,20 @@ pub struct EventRename<'a> {
 /// Represent a destination file for [`EventRename`].
 #[derive(Debug, PartialEq, Eq, Hash)]
 #[doc(alias = "es_destination_type_t")]
+#[non_exhaustive]
 pub enum EventRenameDestinationFile<'a> {
     /// The destination file already exist at the time of the event.
-    ExistingFile(File<'a>),
+    #[non_exhaustive]
+    ExistingFile {
+        /// The file that will be overwritten by the rename operation.
+        file: File<'a>
+    },
     /// The destination doesn't exist at the time of the event.
+    #[non_exhaustive]
     NewPath {
         /// The directory into which the file will be renamed.
         directory: File<'a>,
-        /// The name of the new file that will be created.
+        /// The filename of the destination of the rename operation.
         filename: &'a OsStr,
     },
 }
@@ -42,9 +48,9 @@ impl<'a> EventRename<'a> {
         match self.raw.destination_type {
             es_destination_type_t::ES_DESTINATION_TYPE_EXISTING_FILE => {
                 // Safety: Safe as we select the union field corresponding to that type.
-                Some(EventRenameDestinationFile::ExistingFile(unsafe {
-                    File::new(self.raw.destination.existing_file.as_ref())
-                }))
+                Some(EventRenameDestinationFile::ExistingFile {
+                    file: File::new(unsafe { self.raw.destination.existing_file.as_ref() })
+                })
             },
             es_destination_type_t::ES_DESTINATION_TYPE_NEW_PATH => {
                 // Safety: Safe as we select the union fields corresponding to that type.


### PR DESCRIPTION
This makes it easier to add variants to the enums without fear of breaking downstream users.