### PR TITLE
Remove `sysinfo`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -116,7 +116,7 @@ jobs:
     strategy:
       matrix:
         version:
-        - { name: MSRV, value: "1.88.0" }
+        - { name: MSRV, value: "1.85.0" }
         - { name: Stable, value: stable }
 
     steps:
@@ -156,7 +156,7 @@ jobs:
       matrix:
         version:
         # Only build older macOS on the MSRV, since that's the likely use case
-        - { name: MSRV, value: "1.88.0" }
+        - { name: MSRV, value: "1.85.0" }
         os:
         # There are no 10.15, 11.3, 12, nor 13 runners anymore.
         # To avoid reaching the Github Actions limits, we only test for the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "bitflags"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
-
-[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,7 +19,6 @@ dependencies = [
  "libc",
  "mach2",
  "static_assertions",
- "sysinfo",
  "trybuild",
 ]
 
@@ -86,21 +79,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
-name = "memchr"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "ntapi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,29 +88,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-
-[[package]]
-name = "objc2-io-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
-dependencies = [
- "libc",
- "objc2-core-foundation",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -222,20 +181,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "windows",
 ]
 
 [[package]]
@@ -343,116 +288,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
-dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
-dependencies = [
- "windows-core",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
-dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
-dependencies = [
- "windows-core",
- "windows-link",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["HarfangLab Rust Team"]
 license = "MIT OR Apache-2.0"
 edition = "2024"
 repository = "https://github.com/HarfangLab/endpoint-sec"
-rust-version = "1.88"
+rust-version = "1.85"
 
 [workspace]
 members = ["endpoint-sec/", "endpoint-sec-sys/"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,4 @@ objc2 = "0.6"
 static_assertions = "1.1"
 
 # External - For tests
-sysinfo = "0.38"
 trybuild = "1.0"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository is composed of two Rust crates:
 
 ## MSRV
 
-The current MSRV is 1.88.0. It can be updated in any minor version, though
+The current MSRV is 1.85.0. It can be updated in any minor version, though
 we'll try to be conservative with it. Typically, we'll try to keep it at least
 10 versions behind the current stable release.
 

--- a/endpoint-sec/Cargo.toml
+++ b/endpoint-sec/Cargo.toml
@@ -51,7 +51,6 @@ libc.workspace = true
 static_assertions = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "macos")'.dev-dependencies]
-sysinfo.workspace = true
 trybuild.workspace = true
 
 [package.metadata.docs.rs]

--- a/endpoint-sec/src/audit.rs
+++ b/endpoint-sec/src/audit.rs
@@ -231,37 +231,27 @@ unsafe extern "C" {
 #[cfg(test)]
 #[cfg(feature = "audit_token_from_pid")]
 mod test {
-    use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System, UpdateKind};
+    use std::ffi::{c_char, c_void};
+    use std::mem::MaybeUninit;
+    use std::{io, ptr};
+
+    use libc::{ESRCH, MAXCOMLEN};
 
     use super::*;
 
     #[test]
     fn audit_token_from_pid() {
-        let proc_refr_kind = ProcessRefreshKind::nothing().with_user(UpdateKind::OnlyIfNotSet);
-        let mut s = System::new_with_specifics(RefreshKind::nothing().with_processes(proc_refr_kind));
+        for proc in get_proc_infos().unwrap() {
+            let pid = proc.pbsi_pid;
+            let proc_euid = proc.pbsi_uid;
+            let proc_egid = proc.pbsi_gid;
 
-        // Pre-collect in order to allow for mutable borrows in the loop.
-        // `Process` is not clonable, so gather its data ahead of time...
-        for (pid, proc_euid, proc_egid) in s
-            .processes()
-            .iter()
-            .map(|(pid, proc)| {
-                (
-                    *pid,
-                    proc.effective_user_id().map_or(0, |x| **x),
-                    proc.effective_group_id().map_or(0, |x| *x),
-                )
-            })
-            .collect::<Vec<_>>()
-        {
-            let audit_token = match AuditToken::from_pid(pid.as_u32() as pid_t) {
+            let audit_token = match AuditToken::from_pid(pid as pid_t) {
                 Ok(at) => at,
                 Err(err) => {
                     // The error is not filterable and can simply be due to the
                     // process having exited since, so check for that before panicking.
-                    s.refresh_processes_specifics(ProcessesToUpdate::Some(&[pid]), true, proc_refr_kind);
-
-                    if s.process(pid).is_some() {
+                    if proc_is_alive(pid as pid_t).unwrap() {
                         panic!(
                             "`AuditToken::from_pid({})` failed while the process is still alive: {:?}",
                             pid, err,
@@ -274,7 +264,123 @@ mod test {
 
             assert_eq!(proc_euid, audit_token.euid());
             assert_eq!(proc_egid, audit_token.egid());
-            assert_eq!(pid.as_u32(), audit_token.pid() as u32);
+            assert_eq!(pid, audit_token.pid() as u32);
         }
+    }
+
+    /// A convenience composition of [`get_procs`] and [`get_proc_info`].
+    fn get_proc_infos() -> Result<Vec<proc_bsdshortinfo>, io::Error> {
+        get_procs()?.into_iter().map(get_proc_info).collect()
+    }
+
+    /// Returns the list of the PIDs of the processes currently running.
+    fn get_procs() -> Result<Vec<pid_t>, io::Error> {
+        // SAFETY: giving a null pointer and a zero size returns the process count.
+        let count = unsafe { libc::proc_listallpids(ptr::null_mut(), 0) };
+
+        if count <= 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let mut pids = Vec::<pid_t>::with_capacity(count as usize);
+        let ffi_pids = pids.spare_capacity_mut();
+        // SAFETY:
+        //  * the given buffer is correctly allocated for `count` elements;
+        //  * the specified buffer size is consistent with it and its elements;
+        let new_count = unsafe {
+            libc::proc_listallpids(
+                ffi_pids.as_mut_ptr().cast::<c_void>(),
+                (ffi_pids.len() * mem::size_of::<pid_t>()) as i32,
+            )
+        };
+
+        if new_count <= 0 || new_count > count {
+            Err(io::Error::last_os_error())
+        } else {
+            // Set the vector length to what was actually written.
+            // SAFETY: the `new_count` can only be <= to the capacity here.
+            unsafe { pids.set_len(new_count as usize) };
+            Ok(pids)
+        }
+    }
+
+    /// Returns the short BSD info of the process identified by the given PID.
+    fn get_proc_info(pid: pid_t) -> Result<proc_bsdshortinfo, io::Error> {
+        let mut info = MaybeUninit::<proc_bsdshortinfo>::uninit();
+        // SAFETY:
+        //  * the buffer pointer points to an available stack space;
+        //  * the specified buffer size is consistent with it and its elements;
+        //  * the specified info type is consistent with the buffer;
+        let res = unsafe {
+            libc::proc_pidinfo(
+                pid,
+                PROC_PIDT_SHORTBSDINFO,
+                0,
+                ptr::from_mut(&mut info).cast(),
+                mem::size_of::<proc_bsdshortinfo>() as _,
+            )
+        };
+
+        if res != mem::size_of::<proc_bsdshortinfo>() as c_int {
+            Err(io::Error::last_os_error())
+        } else {
+            // SAFETY: the call succeeded at this point.
+            Ok(unsafe { info.assume_init() })
+        }
+    }
+
+    /// Returns `true` if the process identified by the given PID is still alive.
+    fn proc_is_alive(pid: pid_t) -> Result<bool, io::Error> {
+        // A signal of 0 only performs a liveness check.
+        // SAFETY: always safe to call.
+        if unsafe { libc::kill(pid, 0) } == 0 {
+            return Ok(true);
+        }
+
+        // `kill` failed but it might not be because the process is dead.
+        let err = io::Error::last_os_error();
+
+        // If `errno` is equal to `ESCHR`, then it means the process is dead.
+        // UNWRAP: the error was built from `io::Error::last_os_error`.
+        if err.raw_os_error().unwrap() == ESRCH {
+            Ok(false)
+        } else {
+            Err(err)
+        }
+    }
+
+    // TODO: remove when https://github.com/rust-lang/libc/pull/5110 is merged and released.
+
+    const PROC_PIDT_SHORTBSDINFO: c_int = 13;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[repr(C)]
+    struct proc_bsdshortinfo {
+        /// Process ID.
+        pbsi_pid: u32,
+        /// Process parent ID.
+        pbsi_ppid: u32,
+        /// Process perp ID.
+        pbsi_pgid: u32,
+        /// `p_stat` value: `SZOMB`, `SRUN`, etc.
+        pbsi_status: u32,
+        /// Up to 16 characters of process name.
+        pbsi_comm: [c_char; MAXCOMLEN],
+        /// 64bit, emulated, etc.
+        pbsi_flags: u32,
+        /// Current UID on process.
+        pbsi_uid: uid_t,
+        /// Current GID on process.
+        pbsi_gid: gid_t,
+        /// Current RUID on process.
+        pbsi_ruid: uid_t,
+        /// Current RGID on process.
+        pbsi_rgid: gid_t,
+        /// Current SVUID on process.
+        pbsi_svuid: uid_t,
+        /// Current SVGID on process.
+        pbsi_svgid: gid_t,
+        /// Reserved for future use.
+        pbsi_rfu: u32,
     }
 }

--- a/endpoint-sec/src/lib.rs
+++ b/endpoint-sec/src/lib.rs
@@ -32,8 +32,6 @@
 
 // Reexports [`endpoint_sec_sys`]
 pub use endpoint_sec_sys as sys;
-#[cfg(all(test, not(feature = "audit_token_from_pid")))]
-use sysinfo as _;
 #[cfg(test)]
 use trybuild as _;
 


### PR DESCRIPTION
As can be seen in #148, `sysinfo` v0.39 bumps its MSRV to 1.95 with
https://github.com/GuillaumeGomez/sysinfo/pull/1650. 1.95 is the current
stable Rust version. This is too aggressive in my opinion and means we
(I) will get spammed with failing Dependabot PRs for at least a year,
which definitely bothers me. However, our use of it in this crate is
currently very limited: only for a single test and only for a few
process data. This therefore proposes to remove the dependency entirely.

The relevant code is simply vendored in the concerned module. Some
improvements to it are also included regarding error handling, safety
concerns, and minimalism by using the "BSD short info" libproc API.

Then, the MSRV is lowered back to what it was before the latest sysinfo
update: with the dependency removed, there is now no need to maintain
a higher MSRV than necessary for the 2024 Rust edition anymore.