### PR TITLE
Fix(es/evt/sudo): Make `reject_info` a more direct accessor

### DIFF
--- a/endpoint-sec/src/event/event_sudo.rs
+++ b/endpoint-sec/src/event/event_sudo.rs
@@ -22,19 +22,16 @@ impl<'a> EventSudo<'a> {
     /// Optional. When success is false, describes why sudo was rejected
     #[inline(always)]
     pub fn reject_info(&self) -> Option<RejectInfo<'a>> {
-        match self.success() && (self.raw.reject_info.is_null() == false) {
-            false => None,
-            true => Some(RejectInfo {
-                // Safety: 'a tied to self, object obtained through ES
-                raw: unsafe { &*self.raw.reject_info },
-            }),
-        }
+        // Safety: 'a tied to self, object obtained through ES.
+        unsafe { self.raw.reject_info.as_ref() }.map(|rri| RejectInfo { raw: rri })
     }
+
     /// Describes whether or not the from_uid is interpretable
     #[inline(always)]
     pub fn has_from_uid(&self) -> bool {
         self.raw.has_from_uid
     }
+
     /// Optional. The uid of the user who initiated the su
     #[inline(always)]
     pub fn from_uid(&self) -> Option<uid_t> {
@@ -42,17 +39,20 @@ impl<'a> EventSudo<'a> {
         #[allow(clippy::unnecessary_lazy_evaluations)]
         self.has_from_uid().then(|| unsafe { self.raw.from_uid.uid })
     }
+
     /// Optional. The name of the user who initiated the su
     #[inline(always)]
     pub fn from_username(&self) -> Option<&'a OsStr> {
         // Safety: 'a tied to self, object obtained through ES
         unsafe { self.raw.from_username.as_opt_os_str() }
     }
+
     /// Describes whether or not the to_uid is interpretable
     #[inline(always)]
     pub fn has_to_uid(&self) -> bool {
         self.raw.has_to_uid
     }
+
     /// Optional. If success, the user ID that is going to be substituted
     #[inline(always)]
     pub fn to_uid(&self) -> Option<uid_t> {
@@ -63,6 +63,7 @@ impl<'a> EventSudo<'a> {
         #[allow(clippy::unnecessary_lazy_evaluations)]
         self.has_to_uid().then(|| unsafe { self.raw.to_uid.uid })
     }
+
     /// Optional. If success, the user name that is going to be substituted
     #[inline(always)]
     pub fn to_username(&self) -> Option<&'a OsStr> {
@@ -72,6 +73,7 @@ impl<'a> EventSudo<'a> {
         // Safety: 'a tied to self, object obtained through ES
         unsafe { Some(self.raw.to_username.as_os_str()) }
     }
+
     /// Optional. The command to be run
     #[inline(always)]
     pub fn command(&self) -> Option<&'a OsStr> {
@@ -101,11 +103,13 @@ impl<'a> RejectInfo<'a> {
         // Safety: 'a tied to self, object obtained through ES
         unsafe { self.raw.plugin_name.as_os_str() }
     }
+
     /// The sudo plugin type that initiated the reject
     #[inline(always)]
     pub fn plugin_type(&self) -> es_sudo_plugin_type_t {
         self.raw.plugin_type
     }
+
     /// A reason represented by a string for the failure
     #[inline(always)]
     pub fn failure_message(&self) -> &'a OsStr {


### PR DESCRIPTION
Fixes #159 by removing the (broken) logic related to `self.success()` entirely and making the method a more direct accessor to the raw data.