### PR TITLE
fix(deps): correct minimal version for `libc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ endpoint-sec-sys = { version = "0.6.1", path = "./endpoint-sec-sys" }
 
 # External - For libs
 block2 = "0.6"
-libc = { version = "0.2", features = ["extra_traits"] }
+libc = { version = "0.2.188", features = ["extra_traits"] }
 mach2 = "0.7"
 objc2 = "0.6"
 static_assertions = "1.1"


### PR DESCRIPTION
Since 7d47ddab849891575399c3f99b994af62e0f7552 "Chore: Downstream proc_bsdshortinfo from libc", the minimal required version for `libc` has become `0.2.188`.